### PR TITLE
Support ingesting all FHIR resource types

### DIFF
--- a/Ship.Ses.Ingestor.Api/src/Ship.Ses.Transmitter.Application/Interfaces/IStatusEventRepository.cs
+++ b/Ship.Ses.Ingestor.Api/src/Ship.Ses.Transmitter.Application/Interfaces/IStatusEventRepository.cs
@@ -13,7 +13,7 @@ namespace Ship.Ses.Transmitter.Application.Interfaces
         //Task AddAsync(StatusEvent statusEvent); 
 
         Task<(StatusEvent persisted, bool duplicate, bool conflict)>
-        UpsertPatientStatusAsync(StatusEvent incoming, CancellationToken ct);
+        UpsertStatusEventAsync(StatusEvent incoming, CancellationToken ct);
         Task<StatusEvent?> GetByTransactionIdAsync(string transactionId, CancellationToken ct);
         Task<StatusEvent?> GetByCorrelationIdAsync(string transactionId, CancellationToken ct);
     }

--- a/Ship.Ses.Ingestor.Api/src/Ship.Ses.Transmitter.Application/Patients/IFhirIngestService.cs
+++ b/Ship.Ses.Ingestor.Api/src/Ship.Ses.Transmitter.Application/Patients/IFhirIngestService.cs
@@ -10,6 +10,6 @@ namespace Ship.Ses.Transmitter.Application.Patients
     public interface IFhirIngestService
     {
         //Task IngestAsync(FhirIngestRequest request, string clientId);
-        Task<IdempotentInsertResult<PatientSyncRecord>> IngestAsyncReturningExisting(FhirIngestRequest request, string clientId);
+        Task<IdempotentInsertResult<FhirSyncRecord>> IngestAsyncReturningExisting(FhirIngestRequest request, string clientId);
     }
 }

--- a/Ship.Ses.Ingestor.Api/src/Ship.Ses.Transmitter.Domain/Patients/GenericResourceSyncRecord.cs
+++ b/Ship.Ses.Ingestor.Api/src/Ship.Ses.Transmitter.Domain/Patients/GenericResourceSyncRecord.cs
@@ -1,0 +1,7 @@
+namespace Ship.Ses.Transmitter.Domain.Patients
+{
+    public class GenericResourceSyncRecord : FhirSyncRecord
+    {
+        public override string CollectionName => "transformed_pool_resources";
+    }
+}

--- a/Ship.Ses.Ingestor.Api/src/Ship.Ses.Transmitter.Domain/Patients/IMongoSyncRepository.cs
+++ b/Ship.Ses.Ingestor.Api/src/Ship.Ses.Transmitter.Domain/Patients/IMongoSyncRepository.cs
@@ -14,10 +14,10 @@ namespace Ship.Ses.Transmitter.Domain.Patients
         Task AddRecordAsync<T>(T record) where T : FhirSyncRecord;
         Task UpdateRecordAsync<T>(T record) where T : FhirSyncRecord;
         Task<IEnumerable<T>> GetByStatusAsync<T>(string status, int skip = 0, int take = 100) where T : FhirSyncRecord, new();
-        Task<IdempotentInsertResult<PatientSyncRecord>> TryInsertIdempotentAsync(PatientSyncRecord record);
+        Task<IdempotentInsertResult<T>> TryInsertIdempotentAsync<T>(T record) where T : FhirSyncRecord;
         Task BulkUpdateStatusAsync<T>(
     Dictionary<ObjectId, (string status, string message, string transactionId, string rawResponse)> updates
 ) where T : FhirSyncRecord, new();
-        Task<FhirSyncRecord> GetPatientByTransactionIdAsync(string transactionId, CancellationToken cancellationToken);
+        Task<FhirSyncRecord?> GetByTransactionIdAsync(string transactionId, CancellationToken cancellationToken);
     }
 }

--- a/Ship.Ses.Ingestor.Api/src/Ship.Ses.Transmitter.Domain/SyncModels/StatusEvent.cs
+++ b/Ship.Ses.Ingestor.Api/src/Ship.Ses.Transmitter.Domain/SyncModels/StatusEvent.cs
@@ -7,7 +7,7 @@ namespace Ship.Ses.Transmitter.Domain.SyncModels
 {
     //using Ship.Ses.Transmitter.Domain.Attributes; 
 
-    //[BsonCollectionName("patientstatusevents")]
+    //[BsonCollectionName("fhirstatusevents")]
 
     public sealed class StatusEvent : BaseMongoDocument
     {
@@ -15,7 +15,7 @@ namespace Ship.Ses.Transmitter.Domain.SyncModels
         public string TransactionId { get; set; } = default!;
 
         [BsonElement("resourceType")]
-        public string ResourceType { get; set; } = "Patient"; // inferred from Data.resourceType
+        public string ResourceType { get; set; } = default!; // inferred from Data.resourceType
 
         [BsonElement("resourceId")]
         public string? ResourceId { get; set; }                // inferred from Data.id (if present)
@@ -73,7 +73,7 @@ namespace Ship.Ses.Transmitter.Domain.SyncModels
         public string? ClientId { get; set; }
         [BsonElement("facilityId")]
         public string? FacilityId { get; set; }
-        public override string CollectionName => "patientstatusevents";
+        public override string CollectionName => "fhirstatusevents";
     }
 
 

--- a/Ship.Ses.Ingestor.Api/src/Ship.Ses.Transmitter.Infrastructure/Persistance/Configuration/Domain/StatusEventRepository.cs
+++ b/Ship.Ses.Ingestor.Api/src/Ship.Ses.Transmitter.Infrastructure/Persistance/Configuration/Domain/StatusEventRepository.cs
@@ -15,7 +15,7 @@ namespace Ship.Ses.Transmitter.Infrastructure.Persistance.Configuration.Domain
     public sealed class StatusEventRepository : IStatusEventRepository
     {
         private readonly IMongoCollection<StatusEvent> _col;
-        public StatusEventRepository(IMongoDatabase db) => _col = db.GetCollection<StatusEvent>("patientstatusevents");
+        public StatusEventRepository(IMongoDatabase db) => _col = db.GetCollection<StatusEvent>("fhirstatusevents");
         private readonly IMongoDatabase _database;
 
         /// <summary>
@@ -30,9 +30,9 @@ namespace Ship.Ses.Transmitter.Infrastructure.Persistance.Configuration.Domain
                 throw new ArgumentException("SourceDbSettings or DatabaseName is not configured for MongoSyncRepository.", nameof(settings));
             }
             _database = client.GetDatabase(settings.Value.DatabaseName);
-            _col = _database.GetCollection<StatusEvent>("patientstatusevents");
+            _col = _database.GetCollection<StatusEvent>("fhirstatusevents");
         }
-        public async Task<(StatusEvent persisted, bool duplicate, bool conflict)>  UpsertPatientStatusAsync(StatusEvent incoming, CancellationToken ct)
+        public async Task<(StatusEvent persisted, bool duplicate, bool conflict)>  UpsertStatusEventAsync(StatusEvent incoming, CancellationToken ct)
         {
             try
             {
@@ -92,7 +92,7 @@ namespace Ship.Ses.Transmitter.Infrastructure.Persistance.Configuration.Domain
     //    public StatusEventRepository(IMongoClient client, string databaseName)
     //    {
     //        var database = client.GetDatabase(databaseName);
-    //        _statusEvents = database.GetCollection<StatusEvent>("patientstatusevents");
+    //        _statusEvents = database.GetCollection<StatusEvent>("fhirstatusevents");
     //    }
 
     //    public async Task<StatusEvent> FindByTransactionIdAsync(string transactionId)

--- a/Ship.Ses.Ingestor.Api/src/Ship.Ses.Transmitter.Infrastructure/Persistance/Configuration/Domain/Sync/ClientSyncMetricsCollector.cs
+++ b/Ship.Ses.Ingestor.Api/src/Ship.Ses.Transmitter.Infrastructure/Persistance/Configuration/Domain/Sync/ClientSyncMetricsCollector.cs
@@ -4,7 +4,6 @@ using MongoDB.Bson;
 using MongoDB.Driver;
 using Ship.Ses.Transmitter.Application.Interfaces;
 using Ship.Ses.Transmitter.Application.Sync;
-using Ship.Ses.Transmitter.Domain.Encounter;
 using Ship.Ses.Transmitter.Domain.Patients;
 using Ship.Ses.Transmitter.Domain.Sync;
 using Ship.Ses.Transmitter.Infrastructure.Settings;
@@ -33,9 +32,8 @@ namespace Ship.Ses.Transmitter.Worker
 
             _resourceMap = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase)
             {
-                { "Patient", typeof(PatientSyncRecord) },
-                { "Encounter", typeof(EncounterSyncRecord) }
-                // Add new resource mappings here
+                { "Patient", typeof(PatientSyncRecord) }
+                // Non-patient resources fall back to GenericResourceSyncRecord
             };
         }
 
@@ -70,7 +68,10 @@ namespace Ship.Ses.Transmitter.Worker
 
             foreach (var resource in enabledResources)
             {
-                if (!_resourceMap.TryGetValue(resource, out var modelType)) continue;
+                if (!_resourceMap.TryGetValue(resource, out var modelType))
+                {
+                    modelType = typeof(GenericResourceSyncRecord);
+                }
 
                 var instance = (FhirSyncRecord)Activator.CreateInstance(modelType);
                 var collection = _mongoDatabase.GetCollection<BsonDocument>(instance.CollectionName);
@@ -116,7 +117,10 @@ namespace Ship.Ses.Transmitter.Worker
 
             foreach (var resource in enabledResources)
             {
-                if (!_resourceMap.TryGetValue(resource, out var modelType)) continue;
+                if (!_resourceMap.TryGetValue(resource, out var modelType))
+                {
+                    modelType = typeof(GenericResourceSyncRecord);
+                }
 
                 var instance = (FhirSyncRecord)Activator.CreateInstance(modelType);
                 var collection = _mongoDatabase.GetCollection<BsonDocument>(instance.CollectionName);


### PR DESCRIPTION
## Summary
- persist non-patient FHIR resources with a new GenericResourceSyncRecord and collection
- generalize the ingest service and Mongo repository to handle any resource type and expose GetByTransactionIdAsync
- rename the status-event collection to fhirstatusevents while updating callbacks and metrics to honor all resource types

## Testing
- dotnet build *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68dcaa6439c0832da0e88a21f4f11188