### PR TITLE
Converge SHIP callbacks via upsert-by-transactionId (fix duplicate EMR callbacks)

### DIFF
--- a/Ship.Ses.Ingestor.Api/src/Ship.Ses.Ingestor.Application/Interfaces/IStatusEventRepository.cs
+++ b/Ship.Ses.Ingestor.Api/src/Ship.Ses.Ingestor.Application/Interfaces/IStatusEventRepository.cs
@@ -1,4 +1,4 @@
-﻿using Ship.Ses.Ingestor.Domain.SyncModels;
+using Ship.Ses.Ingestor.Domain.SyncModels;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,15 +7,32 @@ using System.Threading.Tasks;
 
 namespace Ship.Ses.Ingestor.Application.Interfaces
 {
+    /// <summary>
+    /// Result of correlating a SHIP callback onto the shared <c>fhirstatusevents</c> document.
+    /// </summary>
+    public enum StatusCallbackOutcome
+    {
+        /// <summary>No event existed for the transactionId; a SHIP-first document was inserted.</summary>
+        Inserted,
+
+        /// <summary>An existing event (Transmitter seed or probe result) was enriched/converged in place.</summary>
+        Updated,
+
+        /// <summary>An existing event already reflected this callback; nothing changed (idempotent no-op).</summary>
+        Unchanged
+    }
+
     public interface IStatusEventRepository
     {
-        //Task<StatusEvent> FindByTransactionIdAsync(string transactionId);
-        //Task AddAsync(StatusEvent statusEvent); 
-
-        Task<(StatusEvent persisted, bool duplicate, bool conflict)>
+        /// <summary>
+        /// Correlates the SHIP callback to the existing <c>fhirstatusevents</c> document by
+        /// <c>transactionId</c> and applies it via a single atomic upsert. Never blind-inserts:
+        /// SHIP is authoritative over PROBE, delivery/outbox state is preserved, and exactly one
+        /// corrective EMR delivery is re-armed only when a delivered outcome is overwritten.
+        /// </summary>
+        Task<(StatusEvent persisted, StatusCallbackOutcome outcome)>
         UpsertStatusEventAsync(StatusEvent incoming, CancellationToken ct);
         Task<StatusEvent?> GetByTransactionIdAsync(string transactionId, CancellationToken ct);
         Task<StatusEvent?> GetByCorrelationIdAsync(string transactionId, CancellationToken ct);
     }
 }
-

--- a/Ship.Ses.Ingestor.Api/src/Ship.Ses.Ingestor.Application/Services/StatusCallbackService.cs
+++ b/Ship.Ses.Ingestor.Api/src/Ship.Ses.Ingestor.Application/Services/StatusCallbackService.cs
@@ -117,28 +117,29 @@ namespace Ship.Ses.Ingestor.Application.Services
 
             };
 
-            //) Upsert with  existing repo logic (unique on transactionId or (transactionId, source))
-            var (persisted, duplicate, conflict) = await _repository.UpsertStatusEventAsync(newEvent, cancellationToken);
+            // Correlate onto the shared fhirstatusevents document by transactionId via a single atomic
+            // upsert. SHIP is authoritative over PROBE: a divergent outcome converges the existing event
+            // (and re-arms one corrective EMR delivery when already delivered) rather than 409-conflicting.
+            var (persisted, outcome) = await _repository.UpsertStatusEventAsync(newEvent, cancellationToken);
 
-            if (conflict)
+            switch (outcome)
             {
-                _logger.LogError("Transaction Status already accepted for transactionId {TxId}. The incoming payload conflicts with an existing record.", request.TransactionId);
-                throw new InvalidOperationException("Conflicting payload for the same transactionId; existing record retained.");
-            }
-            else if (duplicate)
-            {
-                _logger.LogInformation("Callback received for transactionId {TxId}. record updated.", request.TransactionId);
-            }
-            else
-            {
-                _logger.LogInformation("Successfully recorded new status event for transactionId {TxId}.", request.TransactionId);
+                case StatusCallbackOutcome.Inserted:
+                    _logger.LogInformation("Recorded new SHIP status event for transactionId {TxId} with status {Status}.", request.TransactionId, persisted.Status);
+                    break;
+                case StatusCallbackOutcome.Updated:
+                    _logger.LogInformation("Converged existing status event for transactionId {TxId} to SHIP status {Status}.", request.TransactionId, persisted.Status);
+                    break;
+                default:
+                    _logger.LogInformation("Duplicate SHIP callback for transactionId {TxId}; existing status {Status} unchanged.", request.TransactionId, persisted.Status);
+                    break;
             }
 
             return new PatientTransmissionStatusResponse
             {
                 TransactionId = persisted.TransactionId,
                 StatusRecorded = persisted.Status,
-                Duplicate = duplicate,
+                Duplicate = outcome == StatusCallbackOutcome.Unchanged,
                 RecordedAt = new DateTimeOffset(persisted.ReceivedAtUtc, TimeSpan.Zero)
             };
         }

--- a/Ship.Ses.Ingestor.Api/src/Ship.Ses.Ingestor.Infrastructure/Repositories/StatusEventRepository.cs
+++ b/Ship.Ses.Ingestor.Api/src/Ship.Ses.Ingestor.Infrastructure/Repositories/StatusEventRepository.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Options;
+using MongoDB.Bson;
 using MongoDB.Driver;
 using Ship.Ses.Ingestor.Application.Interfaces;
 using Ship.Ses.Ingestor.Domain.Patients;
@@ -32,26 +33,126 @@ namespace Ship.Ses.Ingestor.Infrastructure.Repositories
             _database = client.GetDatabase(settings.Value.DatabaseName);
             _col = _database.GetCollection<StatusEvent>("fhirstatusevents");
         }
-        public async Task<(StatusEvent persisted, bool duplicate, bool conflict)>  UpsertStatusEventAsync(StatusEvent incoming, CancellationToken ct)
+        /// <summary>
+        /// Correlates a SHIP callback onto the shared <c>fhirstatusevents</c> document via a single
+        /// atomic aggregation-pipeline upsert keyed on <c>transactionId</c>. Never blind-inserts.
+        /// <para>
+        /// SHIP is authoritative over PROBE. The authoritative fields (<c>source</c>, <c>status</c>,
+        /// <c>message</c>, <c>shipId</c>, <c>receivedAtUtc</c>, <c>payloadHash</c>, <c>headers</c>,
+        /// <c>data</c>) are always written; identity/routing fields are filled only when missing so a
+        /// Transmitter seed is never clobbered. The EMR outbox is preserved except:
+        /// on a fresh insert it starts at Pending/now; and when a SHIP status differs from an
+        /// already-delivered stored status (<c>callbackStatus == "Succeeded"</c>) exactly one corrective
+        /// delivery is re-armed. Because the stored status is overwritten to the SHIP value in the same
+        /// operation, a later repeat of that corrected outcome compares equal and does not re-arm.
+        /// </para>
+        /// </summary>
+        public async Task<(StatusEvent persisted, StatusCallbackOutcome outcome)> UpsertStatusEventAsync(StatusEvent incoming, CancellationToken ct)
         {
-            try
+            if (incoming is null) throw new ArgumentNullException(nameof(incoming));
+            if (string.IsNullOrWhiteSpace(incoming.TransactionId))
+                throw new ArgumentException("transactionId is required to correlate a status callback.", nameof(incoming));
+
+            var filter = Builders<StatusEvent>.Filter.Eq(x => x.TransactionId, incoming.TransactionId);
+            var update = Builders<StatusEvent>.Update.Pipeline(BuildUpsertPipeline(incoming));
+
+            // The unique partial index on transactionId makes concurrent upserts of a not-yet-seeded txn
+            // safe: one wins the insert, the loser gets a duplicate-key error and retries as a plain
+            // in-place update (the document now exists), so at most one document ever exists per txn.
+            for (var attempt = 0; ; attempt++)
             {
-                await _col.InsertOneAsync(incoming, cancellationToken: ct);
-                return (incoming, duplicate: false, conflict: false);
+                try
+                {
+                    var result = await _col.UpdateOneAsync(filter, update, new UpdateOptions { IsUpsert = true }, ct);
+
+                    StatusCallbackOutcome outcome;
+                    if (result.UpsertedId is not null)
+                        outcome = StatusCallbackOutcome.Inserted;
+                    else if (result.IsModifiedCountAvailable && result.ModifiedCount > 0)
+                        outcome = StatusCallbackOutcome.Updated;
+                    else
+                        outcome = StatusCallbackOutcome.Unchanged;
+
+                    // The response only needs transactionId/status/receivedAtUtc, all written unconditionally,
+                    // so the incoming projection already reflects the persisted authoritative values.
+                    return (incoming, outcome);
+                }
+                catch (MongoWriteException ex)
+                    when (attempt == 0 && ex.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+                {
+                    // Lost the insert race; the document now exists — retry as an in-place update.
+                }
             }
-            catch (MongoWriteException ex) when (ex.WriteError?.Category == ServerErrorCategory.DuplicateKey)
+        }
+
+        /// <summary>
+        /// Builds the aggregation-pipeline <c>$set</c> stage implementing the enrich + conditional
+        /// outbox re-arm policy in one server-side operation. Field references (<c>$status</c>,
+        /// <c>$callbackStatus</c>) read the pre-update document; on an upsert-insert they are missing.
+        /// </summary>
+        private static PipelineDefinition<StatusEvent, StatusEvent> BuildUpsertPipeline(StatusEvent incoming)
+        {
+            // $literal keeps caller-supplied values (which may contain '$' or look like field paths)
+            // from being interpreted as aggregation expressions.
+            static BsonValue Lit(string? s) => new BsonDocument("$literal", s is null ? BsonNull.Value : new BsonString(s));
+            static BsonDocument Cond(BsonValue ifExpr, BsonValue then, BsonValue @else) =>
+                new BsonDocument("$cond", new BsonArray { ifExpr, then, @else });
+            static BsonValue IfNull(string field, string? incomingValue) =>
+                new BsonDocument("$ifNull", new BsonArray { "$" + field, Lit(incomingValue) });
+
+            // On an upsert-insert callbackStatus is absent; on any existing document it is present.
+            var isInsert = new BsonDocument("$eq",
+                new BsonArray { new BsonDocument("$type", "$callbackStatus"), "missing" });
+
+            // The SHIP status differs from what is stored AND the event was already delivered.
+            var reArm = new BsonDocument("$and", new BsonArray
             {
-                var existing = await _col.Find(x => x.TransactionId == incoming.TransactionId)
-                                         .FirstOrDefaultAsync(ct);
+                new BsonDocument("$ne", new BsonArray { "$status", Lit(incoming.Status) }),
+                new BsonDocument("$eq", new BsonArray { "$callbackStatus", "Succeeded" })
+            });
 
-                if (existing is null) return (incoming, false, conflict: true);
+            BsonValue receivedAt = new BsonDateTime(DateTime.SpecifyKind(incoming.ReceivedAtUtc, DateTimeKind.Utc));
+            BsonValue data = incoming.Data is null
+                ? new BsonDocument("$literal", BsonNull.Value)
+                : new BsonDocument("$literal", incoming.Data);
 
-                var same = existing.PayloadHash == incoming.PayloadHash
-                           && existing.Status == incoming.Status
-                           && existing.ShipId == incoming.ShipId;
+            var set = new BsonDocument
+            {
+                // Correlation key (redundant with the filter on insert; identical on update).
+                { "transactionId", Lit(incoming.TransactionId) },
 
-                return (existing, duplicate: same, conflict: !same);
-            }
+                // Authoritative SHIP fields — always overwritten.
+                { "source", "SHIP" },
+                { "status", Lit(incoming.Status) },
+                { "message", Lit(incoming.Message) },
+                { "shipId", Lit(incoming.ShipId) },
+                { "receivedAtUtc", receivedAt },
+                { "payloadHash", Lit(incoming.PayloadHash) },
+                { "headers", Lit(incoming.Headers) },
+                { "data", data },
+
+                // Identity / routing — fill only when the stored document lacks them (never clobber a seed).
+                { "correlationId", IfNull("correlationId", incoming.CorrelationId) },
+                { "clientId", IfNull("clientId", incoming.ClientId) },
+                { "facilityId", IfNull("facilityId", incoming.FacilityId) },
+                { "resourceType", IfNull("resourceType", incoming.ResourceType) },
+                { "resourceId", IfNull("resourceId", incoming.ResourceId) },
+                { "shipService", IfNull("shipService", incoming.ShipService) },
+                { "emrTargetUrl", IfNull("emrTargetUrl", incoming.EmrTargetUrl) },
+
+                // EMR outbox — default on insert, re-arm exactly one corrective delivery, else preserve.
+                { "callbackStatus", Cond(isInsert, "Pending", Cond(reArm, "Pending", "$callbackStatus")) },
+                { "callbackNextAttemptAt", Cond(isInsert, "$$NOW", Cond(reArm, "$$NOW", "$callbackNextAttemptAt")) },
+                { "callbackLastError", Cond(isInsert, BsonNull.Value, Cond(reArm, BsonNull.Value, "$callbackLastError")) },
+                { "callbackAttempts", Cond(isInsert, 0, "$callbackAttempts") },
+                { "callbackDeliveredAt", Cond(isInsert, BsonNull.Value, "$callbackDeliveredAt") }
+            };
+
+            PipelineDefinition<StatusEvent, StatusEvent> pipeline = new BsonDocument[]
+            {
+                new BsonDocument("$set", set)
+            };
+            return pipeline;
         }
 
         /// <summary>

--- a/Ship.Ses.Ingestor.Api/src/Ship.Ses.Ingestor.WebApi/Installers/StatusEventIndexInitializer.cs
+++ b/Ship.Ses.Ingestor.Api/src/Ship.Ses.Ingestor.WebApi/Installers/StatusEventIndexInitializer.cs
@@ -1,0 +1,73 @@
+using Microsoft.Extensions.Options;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Ship.Ses.Ingestor.Domain.SyncModels;
+using Ship.Ses.Ingestor.Infrastructure.Settings;
+
+namespace Ship.Ses.Ingestor.WebApi.Installers
+{
+    /// <summary>
+    /// Best-effort, idempotent ensure of the partial unique index on <c>fhirstatusevents.transactionId</c>.
+    /// <para>
+    /// The Transmitter OWNS this index and creates it at its own startup; this ensure mirrors the exact
+    /// name and partial spec so, when both run, it is a no-op. It exists so the Ingestor's upsert-by-
+    /// transactionId still enforces the single-document invariant even if the Ingestor happens to start
+    /// first. It never fails startup: conflicts (an already-present compatible index) and connectivity
+    /// problems are logged and swallowed, and the attempt is time-boxed so a missing Mongo cannot stall boot.
+    /// </para>
+    /// </summary>
+    public static class StatusEventIndexInitializer
+    {
+        // Must match the Transmitter exactly.
+        public const string IndexName = "ux_fhirstatusevents_transactionId";
+        private const string CollectionName = "fhirstatusevents";
+
+        public static async Task<WebApplication> EnsureStatusEventIndexesAsync(this WebApplication app)
+        {
+            var log = app.Logger;
+
+            try
+            {
+                var client = app.Services.GetRequiredService<IMongoClient>();
+                var settings = app.Services.GetRequiredService<IOptions<SourceDbSettings>>().Value;
+                var collection = client.GetDatabase(settings.DatabaseName)
+                                       .GetCollection<StatusEvent>(CollectionName);
+
+                var keys = Builders<StatusEvent>.IndexKeys.Ascending(x => x.TransactionId);
+
+                // Partial filter { transactionId: { $gt: "" } } — unique only over non-empty transactionIds.
+                var options = new CreateIndexOptions<StatusEvent>
+                {
+                    Name = IndexName,
+                    Unique = true,
+                    PartialFilterExpression = new BsonDocument("transactionId", new BsonDocument("$gt", ""))
+                };
+
+                // Time-box so an unreachable Mongo cannot stall startup.
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+                await collection.Indexes.CreateOneAsync(
+                    new CreateIndexModel<StatusEvent>(keys, options), cancellationToken: cts.Token);
+
+                log.LogInformation(
+                    "Ensured partial unique index {IndexName} on {Collection} (transactionId).", IndexName, CollectionName);
+            }
+            catch (MongoCommandException ex)
+                when (ex.CodeName is "IndexOptionsConflict" or "IndexKeySpecsConflict")
+            {
+                // The Transmitter (or a prior run) already created a compatible index — leave it in place.
+                log.LogInformation(
+                    "Index {IndexName} on {Collection} already present with a compatible spec; leaving it in place.",
+                    IndexName, CollectionName);
+            }
+            catch (Exception ex)
+            {
+                // Never fail startup on index ensure — the Transmitter owns this index and will create it.
+                log.LogWarning(ex,
+                    "Could not ensure index {IndexName} on {Collection} at startup; continuing (Transmitter owns this index).",
+                    IndexName, CollectionName);
+            }
+
+            return app;
+        }
+    }
+}

--- a/Ship.Ses.Ingestor.Api/src/Ship.Ses.Ingestor.WebApi/Program.cs
+++ b/Ship.Ses.Ingestor.Api/src/Ship.Ses.Ingestor.WebApi/Program.cs
@@ -213,6 +213,10 @@ else
     app.Logger.LogWarning("⚠️ Could not determine server addresses (no IServerAddressesFeature found).");
 }
 
+// Best-effort, idempotent ensure of the Transmitter-owned partial unique index on
+// fhirstatusevents.transactionId, so upsert-by-transactionId enforces one document per txn.
+await app.EnsureStatusEventIndexesAsync();
+
 app.LogEffectiveConfiguration();
 
 app.Logger.LogInformation("SHIP SeS Ingestor API started and ready to accept requests");

--- a/Ship.Ses.Ingestor.Api/src/Ship.Ses.Ingestor.WebApi/Ship.Ses.Ingestor.Api.xml
+++ b/Ship.Ses.Ingestor.Api/src/Ship.Ses.Ingestor.WebApi/Ship.Ses.Ingestor.Api.xml
@@ -17,6 +17,18 @@
             No secret values (client/HMAC secrets, Mongo connection string) are written to the log.
             </summary>
         </member>
+        <member name="T:Ship.Ses.Ingestor.WebApi.Installers.StatusEventIndexInitializer">
+            <summary>
+            Best-effort, idempotent ensure of the partial unique index on <c>fhirstatusevents.transactionId</c>.
+            <para>
+            The Transmitter OWNS this index and creates it at its own startup; this ensure mirrors the exact
+            name and partial spec so, when both run, it is a no-op. It exists so the Ingestor's upsert-by-
+            transactionId still enforces the single-document invariant even if the Ingestor happens to start
+            first. It never fails startup: conflicts (an already-present compatible index) and connectivity
+            problems are logged and swallowed, and the attempt is time-boxed so a missing Mongo cannot stall boot.
+            </para>
+            </summary>
+        </member>
         <member name="M:Ship.Ses.Ingestor.Api.Helper.SafeMessageHelper.Sanitize(System.String)">
             <summary>
             Sanitizes a string for safe use in logs or user-facing messages by removing control characters like CR, LF, and tabs.

--- a/Ship.Ses.Ingestor.Api/tests/Ship.Ses.Ingestor.WebApi.IntegrationTests/StatusEventUpsertTests.cs
+++ b/Ship.Ses.Ingestor.Api/tests/Ship.Ses.Ingestor.WebApi.IntegrationTests/StatusEventUpsertTests.cs
@@ -1,0 +1,294 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MongoDB.Bson;
+using MongoDB.Driver;
+using Ship.Ses.Ingestor.Application.Interfaces;
+using Ship.Ses.Ingestor.Domain.SyncModels;
+using Ship.Ses.Ingestor.Infrastructure.Repositories;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Ship.Ses.Ingestor.WebApi.IntegrationTests
+{
+    /// <summary>
+    /// Drives <see cref="StatusEventRepository.UpsertStatusEventAsync"/> against a real MongoDB, with the
+    /// Transmitter-owned partial unique index in place, to prove the SHIP callback converges onto the
+    /// existing <c>fhirstatusevents</c> document instead of inserting a duplicate. Requires a reachable
+    /// Mongo at <see cref="IngestEndToEndFactory.ConnectionString"/>; each run uses a throwaway database.
+    /// </summary>
+    public sealed class StatusEventUpsertTests : IAsyncLifetime
+    {
+        private const string CollectionName = "fhirstatusevents";
+        private const string IndexName = "ux_fhirstatusevents_transactionId";
+
+        private readonly ITestOutputHelper _out;
+        private readonly string _dbName = $"ses_upsert_tests_{Guid.NewGuid():N}";
+        private MongoClient _client = default!;
+        private IMongoDatabase _db = default!;
+        private IMongoCollection<StatusEvent> _col = default!;
+        private StatusEventRepository _repo = default!;
+
+        public StatusEventUpsertTests(ITestOutputHelper output) => _out = output;
+
+        public async Task InitializeAsync()
+        {
+            await AssertMongoIsReachable();
+
+            _client = new MongoClient(IngestEndToEndFactory.ConnectionString);
+            _db = _client.GetDatabase(_dbName);
+            _col = _db.GetCollection<StatusEvent>(CollectionName);
+
+            // Simulate the Transmitter: create the partial unique index on transactionId.
+            var keys = Builders<StatusEvent>.IndexKeys.Ascending(x => x.TransactionId);
+            var options = new CreateIndexOptions<StatusEvent>
+            {
+                Name = IndexName,
+                Unique = true,
+                PartialFilterExpression = new BsonDocument("transactionId", new BsonDocument("$gt", ""))
+            };
+            await _col.Indexes.CreateOneAsync(new CreateIndexModel<StatusEvent>(keys, options));
+
+            _repo = new StatusEventRepository(_db);
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (_client is not null)
+                await _client.DropDatabaseAsync(_dbName);
+        }
+
+        // ---- Acceptance criteria -------------------------------------------------------------
+
+        [Fact]
+        public async Task Seeded_pending_converges_to_ship_outcome_in_place_and_delivers_once()
+        {
+            var tx = NewTx();
+            await SeedTransmitterPending(tx);
+
+            var (_, outcome) = await _repo.UpsertStatusEventAsync(Ship(tx, "SUCCESS", message: "accepted"), CancellationToken.None);
+
+            Assert.Equal(StatusCallbackOutcome.Updated, outcome);
+            Assert.Equal(1, await Count(tx)); // exactly one document
+
+            var doc = await Read(tx);
+            Assert.NotNull(doc);
+            Assert.Equal("SUCCESS", doc!.Status);
+            Assert.Equal("SHIP", doc.Source);
+            Assert.Equal("accepted", doc.Message);
+            Assert.Equal("Pending", doc.CallbackStatus); // outbox already Pending → worker delivers once
+
+            // Transmitter-seeded identity/routing preserved (not clobbered).
+            Assert.Equal("emr-a", doc.ClientId);
+            Assert.Equal("fac-1", doc.FacilityId);
+            Assert.Equal("corr-1", doc.CorrelationId);
+            Assert.Equal("https://emr.example/cb", doc.EmrTargetUrl);
+        }
+
+        [Fact]
+        public async Task Delivered_same_outcome_enriches_but_leaves_outbox_untouched()
+        {
+            var tx = NewTx();
+            await SeedProbeSucceededDelivered(tx, status: "SUCCESS");
+
+            var (_, _) = await _repo.UpsertStatusEventAsync(
+                Ship(tx, "SUCCESS", message: "ship-confirms", shipId: "SHIP-XYZ"), CancellationToken.None);
+
+            Assert.Equal(1, await Count(tx));
+            var doc = await Read(tx);
+            Assert.NotNull(doc);
+
+            // Authoritative fields enriched...
+            Assert.Equal("SHIP", doc!.Source);
+            Assert.Equal("ship-confirms", doc.Message);
+            Assert.Equal("SHIP-XYZ", doc.ShipId);
+            Assert.Equal("SUCCESS", doc.Status);
+
+            // ...but delivery state is untouched → NO second EMR callback.
+            Assert.Equal("Succeeded", doc.CallbackStatus);
+            Assert.Equal(1, doc.CallbackAttempts);
+            Assert.NotNull(doc.CallbackDeliveredAt);
+        }
+
+        [Fact]
+        public async Task Delivered_differing_outcome_overwrites_status_and_rearms_exactly_one_delivery()
+        {
+            var tx = NewTx();
+            var seededNextAttempt = DateTime.UtcNow.AddHours(-1);
+            await SeedProbeSucceededDelivered(tx, status: "SUCCESS", nextAttemptAt: seededNextAttempt, lastError: "prev");
+
+            // Probe said SUCCESS + delivered; SHIP says REJECTED → corrective re-notify.
+            await _repo.UpsertStatusEventAsync(Ship(tx, "REJECTED", message: "rejected by MPI"), CancellationToken.None);
+
+            Assert.Equal(1, await Count(tx));
+            var doc = await Read(tx);
+            Assert.NotNull(doc);
+            Assert.Equal("REJECTED", doc!.Status);
+            Assert.Equal("SHIP", doc.Source);
+
+            // Exactly one corrective delivery armed.
+            Assert.Equal("Pending", doc.CallbackStatus);
+            Assert.Null(doc.CallbackLastError);
+            Assert.True(doc.CallbackNextAttemptAt > seededNextAttempt, "re-arm should refresh callbackNextAttemptAt");
+            Assert.Equal(1, doc.CallbackAttempts);       // attempts preserved by re-arm
+            Assert.NotNull(doc.CallbackDeliveredAt);     // delivered timestamp preserved
+
+            // Loop guard: after the worker delivers the corrective (Succeeded again), a repeat of the SAME
+            // REJECTED outcome must NOT re-arm, because the stored status already equals the SHIP value.
+            await _col.UpdateOneAsync(
+                x => x.TransactionId == tx,
+                Builders<StatusEvent>.Update.Set(x => x.CallbackStatus, "Succeeded")
+                                            .Set(x => x.CallbackDeliveredAt, DateTime.UtcNow));
+
+            await _repo.UpsertStatusEventAsync(Ship(tx, "REJECTED", message: "rejected by MPI (again)"), CancellationToken.None);
+
+            var after = await Read(tx);
+            Assert.Equal("Succeeded", after!.CallbackStatus); // no second re-arm → no delivery loop
+        }
+
+        [Fact]
+        public async Task Repeated_identical_callback_is_a_delivery_no_op()
+        {
+            var tx = NewTx();
+            var ship = Ship(tx, "SUCCESS", message: "accepted"); // reuse the SAME instance for byte-identical $set
+
+            var first = await _repo.UpsertStatusEventAsync(ship, CancellationToken.None);
+            Assert.Equal(StatusCallbackOutcome.Inserted, first.outcome);
+            Assert.Equal(1, await Count(tx));
+
+            var second = await _repo.UpsertStatusEventAsync(ship, CancellationToken.None);
+            Assert.Equal(StatusCallbackOutcome.Unchanged, second.outcome);
+
+            Assert.Equal(1, await Count(tx)); // no duplicate document
+            var doc = await Read(tx);
+            Assert.Equal("Pending", doc!.CallbackStatus); // no re-arm
+            Assert.Equal(0, doc.CallbackAttempts);
+        }
+
+        [Fact]
+        public async Task Ship_first_insert_writes_full_event_ready_for_single_delivery()
+        {
+            var tx = NewTx();
+
+            var (_, outcome) = await _repo.UpsertStatusEventAsync(Ship(tx, "ERROR", message: "mpi error"), CancellationToken.None);
+
+            Assert.Equal(StatusCallbackOutcome.Inserted, outcome);
+            Assert.Equal(1, await Count(tx));
+            var doc = await Read(tx);
+            Assert.NotNull(doc);
+            Assert.Equal("SHIP", doc!.Source);
+            Assert.Equal("ERROR", doc.Status);
+            Assert.Equal("Pending", doc.CallbackStatus);
+            Assert.Equal(0, doc.CallbackAttempts);
+            Assert.Null(doc.CallbackDeliveredAt);
+            Assert.NotNull(doc.CallbackNextAttemptAt);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("   ")]
+        public async Task Missing_transaction_id_is_rejected_and_creates_no_orphan(string tx)
+        {
+            await Assert.ThrowsAsync<ArgumentException>(
+                () => _repo.UpsertStatusEventAsync(Ship(tx, "SUCCESS"), CancellationToken.None));
+
+            // No deliverable orphan event was created.
+            var count = await _col.CountDocumentsAsync(FilterDefinition<StatusEvent>.Empty);
+            Assert.Equal(0, count);
+        }
+
+        // ---- Helpers -------------------------------------------------------------------------
+
+        private static string NewTx() => $"txn-{Guid.NewGuid():N}";
+
+        private static StatusEvent Ship(string tx, string status, string message = "ok", string shipId = "SHIP-1") =>
+            new StatusEvent
+            {
+                TransactionId = tx,
+                Status = status,
+                Message = message,
+                ShipId = shipId,
+                Source = "SHIP",
+                ResourceType = "Patient",
+                ResourceId = string.IsNullOrWhiteSpace(tx) ? "r-1" : tx,
+                ReceivedAtUtc = new DateTime(2026, 1, 2, 3, 4, 5, DateTimeKind.Utc),
+                PayloadHash = $"{status}|{message}|{shipId}"
+            };
+
+        private async Task SeedTransmitterPending(string tx)
+        {
+            await _col.InsertOneAsync(new StatusEvent
+            {
+                TransactionId = tx,
+                Status = "PENDING",
+                Source = "PROBE",
+                Message = "seeded",
+                ShipId = "",
+                ResourceType = "Patient",
+                ResourceId = tx,
+                ReceivedAtUtc = DateTime.UtcNow.AddMinutes(-10),
+                PayloadHash = "seed",
+                ClientId = "emr-a",
+                FacilityId = "fac-1",
+                CorrelationId = "corr-1",
+                EmrTargetUrl = "https://emr.example/cb",
+                CallbackStatus = "Pending",
+                CallbackAttempts = 0,
+                CallbackNextAttemptAt = DateTime.UtcNow,
+                ProbeStatus = "Pending"
+            });
+        }
+
+        private async Task SeedProbeSucceededDelivered(
+            string tx, string status, DateTime? nextAttemptAt = null, string? lastError = null)
+        {
+            await _col.InsertOneAsync(new StatusEvent
+            {
+                TransactionId = tx,
+                Status = status,
+                Source = "PROBE",
+                Message = "probe-promoted",
+                ShipId = "SHIP-SEED",
+                ResourceType = "Patient",
+                ResourceId = tx,
+                ReceivedAtUtc = DateTime.UtcNow.AddMinutes(-10),
+                PayloadHash = "probe",
+                ClientId = "emr-a",
+                FacilityId = "fac-1",
+                CorrelationId = "corr-1",
+                EmrTargetUrl = "https://emr.example/cb",
+                CallbackStatus = "Succeeded",
+                CallbackAttempts = 1,
+                CallbackNextAttemptAt = nextAttemptAt ?? DateTime.UtcNow.AddMinutes(-9),
+                CallbackDeliveredAt = DateTime.UtcNow.AddMinutes(-8),
+                CallbackLastError = lastError,
+                EmrResponseStatusCode = 200,
+                ProbeStatus = "Succeeded"
+            });
+        }
+
+        private Task<StatusEvent?> Read(string tx) =>
+            _col.Find(x => x.TransactionId == tx).FirstOrDefaultAsync()!;
+
+        private async Task<long> Count(string tx) =>
+            await _col.CountDocumentsAsync(x => x.TransactionId == tx);
+
+        private static async Task AssertMongoIsReachable()
+        {
+            try
+            {
+                var client = new MongoClient(IngestEndToEndFactory.ConnectionString);
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+                await client.GetDatabase("admin")
+                            .RunCommandAsync<BsonDocument>(new BsonDocument("ping", 1), cancellationToken: cts.Token);
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException(
+                    $"MongoDB is not reachable at {IngestEndToEndFactory.ConnectionString}. " +
+                    "Start one (e.g. `docker run -d --name ses-mongo-test -p 27017:27017 mongo:7`) and retry.",
+                    ex);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Why

The Transmitter and Ingestor both write the shared `fhirstatusevents` collection. The Ingestor's inbound SHIP callback path was **not** hardened and caused **duplicate EMR callbacks in prod**.

`StatusEventRepository.UpsertStatusEventAsync` did a blind `InsertOneAsync`:

- **No index present** → a *second* document was written with a fresh `callbackStatus="Pending"`, so the EmrCallbackWorker delivered the callback **again**.
- **Index present** → a legitimate `PENDING → SUCCESS` convergence fell into the duplicate-key branch, compared `status` unequal, and threw → **409**. The seeded event was never promoted to the terminal status and **never delivered**.
- No corrective re-notify existed, and the existing document was never enriched.

## What changed

**Atomic upsert-by-transactionId** (`StatusEventRepository.UpsertStatusEventAsync`) — one `UpdateOneAsync` + `IsUpsert` with an aggregation-pipeline `$set`:

- Always writes authoritative SHIP fields: `source`, `status`, `message`, `shipId`, `receivedAtUtc`, `payloadHash`, `headers`, `data`.
- Fills identity/routing (`clientId`, `facilityId`, `correlationId`, `emrTargetUrl`, …) only when missing (`$ifNull`) so a Transmitter seed is never clobbered.
- Drives the outbox with `$cond`: default on insert; **re-arm exactly one** corrective delivery when the SHIP status **differs** *and* the event was already delivered (`callbackStatus="Succeeded"`); otherwise preserve delivery state. Because `status` is overwritten to the SHIP value in the same op, a repeat compares equal → **no re-arm loop**.
- Guards empty `transactionId`; retries once on duplicate-key to absorb an insert race.

**SHIP is authoritative over PROBE** — a divergent outcome now *converges* the existing event instead of 409-ing. The repository returns `StatusCallbackOutcome { Inserted, Updated, Unchanged }`; `StatusCallbackService` maps/logs it and sets `Duplicate = Unchanged` (the conflict→409 throw is removed).

**Startup index ensure** (`StatusEventIndexInitializer`, wired in `Program.cs`) — best-effort, time-boxed, idempotent ensure of the exact Transmitter-owned `ux_fhirstatusevents_transactionId` partial unique index (`{ transactionId: { $gt: "" } }`), so the single-document invariant holds even if the Ingestor starts first. Conflicts and connectivity errors are swallowed and never fail startup.

## Tests

New live-Mongo `StatusEventUpsertTests` (7) covering every acceptance case:

- Seeded PENDING → SHIP outcome converges **in place** (exactly one doc, delivered once).
- Delivered same outcome → data/source **enriched, outbox untouched** (no second callback).
- Delivered differing outcome (probe SUCCESS → SHIP REJECTED) → `status` overwritten, **exactly one** corrective delivery armed; repeat does **not** re-arm (no loop).
- Identical callback twice → delivery **no-op** (no duplicate doc, no re-arm).
- Missing/empty `transactionId` → rejected, **no orphan** deliverable event.

**Results:** build 0 errors; Infrastructure **32**, Integration **13** (7 new + existing E2E/endpoint), Domain **3** — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)